### PR TITLE
Allow templated write_files content

### DIFF
--- a/terraform/module/proxmox/cloud_config/local.tf
+++ b/terraform/module/proxmox/cloud_config/local.tf
@@ -98,7 +98,17 @@ locals { # Logic
             groups = local.groups_computed
             write_files = [
                 for write_file in local.write_files_computed : trimspace(jsonencode({
-                    for k, v in write_file : k => v if v != null
+                    for k, v in merge(
+                        write_file,
+                        write_file.content != null && can(write_file.content.source) ? {
+                            content = base64encode(
+                                templatefile(
+                                    write_file.content.source,
+                                    try(write_file.content.variables, {})
+                                )
+                            )
+                        } : {}
+                    ) : k => v if v != null
                 }))
             ]
         })

--- a/terraform/module/proxmox/cloud_config/variable.tf
+++ b/terraform/module/proxmox/cloud_config/variable.tf
@@ -87,7 +87,7 @@ variable "write_files" {
     description = "List of system users to configure"
     type = list(object({
         path = optional(string)
-        content = optional(string)
+        content = optional(any)
         source = optional(object({
             uri = optional(string)
             headers = optional(map(string))


### PR DESCRIPTION
## Summary
- update `write_files` variable to accept any value for `content`
- support generating `content` from template file with variables

## Testing
- `terraform fmt -recursive` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686aacc06268832ca85144e4d4f42ff9