### PR TITLE
Update gitconfig handling in cloud-init

### DIFF
--- a/terraform/module/proxmox/cloud_config/local.tf
+++ b/terraform/module/proxmox/cloud_config/local.tf
@@ -84,7 +84,17 @@ locals { # Logic
             gitconfig = local.gitconfig_computed
         }))
     }
-    template = { 
+    write_files_gitconfig = local.users_computed == null ? [] : [
+        for user in local.users_computed : trimspace(jsonencode({
+            path = "/home/${user.name}/.gitconfig"
+            permissions = "0640"
+            encoding = "b64"
+            content = local.base64.gitconfig
+            owner = "${user.name}:${user.name}"
+            defer = true
+        }))
+    ]
+    template = {
         
         cloud = templatefile(local.source.cloud, {
             hostname = local.name
@@ -96,13 +106,7 @@ locals { # Logic
                 }))
             ]
             groups = local.groups_computed
-            write_files_base = [
-                trimspace(jsonencode({
-                    path = "/tmp/.gitconfig"
-                    encoding = "b64"
-                    content = local.base64.gitconfig
-                }))
-            ]
+            write_files_gitconfig = local.write_files_gitconfig
             write_files = [
                 for write_file in local.write_files_computed : trimspace(jsonencode({
                     for k, v in write_file : k => v if v != null

--- a/terraform/module/proxmox/cloud_config/template/cloud_config.yaml.tpl
+++ b/terraform/module/proxmox/cloud_config/template/cloud_config.yaml.tpl
@@ -35,7 +35,7 @@ groups:
 
 write_files:
 %{ if write_files != null && length(write_files) > 0 }
-%{ for write_file in write_files_base ~}
+%{ for write_file in write_files_gitconfig ~}
   - ${write_file}
 %{ endfor }
 %{ for write_file in write_files ~}
@@ -50,10 +50,5 @@ runcmd:
 %{ if gitconfig != null && gitconfig.github_pat != null }
   - su - ${jsondecode(user).name} -c "/script/register_github_public_key.sh ${gitconfig.github_pat}"
 %{ endif }
-%{ if gitconfig != null }
-  - cp /tmp/.gitconfig /home/${jsondecode(user).name}/.gitconfig
-  - chown ${jsondecode(user).name}:${jsondecode(user).name} /home/${jsondecode(user).name}/.gitconfig
-%{ endif }
 %{ endfor }
 %{ endif }
-  - rm -rf /tmp/.gitconfig


### PR DESCRIPTION
## Summary
- generate `.gitconfig` directly in each user's home using `write_files_gitconfig`
- remove temporary file copy logic from cloud-config template

## Testing
- `terraform fmt -recursive` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686abaf9aea4832cb1a51c5f8ea248a9