### PR TITLE
Fix groups parameter

### DIFF
--- a/terraform/module/proxmox/cloud_config/local.tf
+++ b/terraform/module/proxmox/cloud_config/local.tf
@@ -101,11 +101,9 @@ locals { # Logic
         }
     ]
 
-    groups_data = local.groups_computed == null ? null : (
-        can(local.groups_computed[0]) ?
-        [for group in local.groups_computed : {"${group}" = []}] :
-        [for group, members in local.groups_computed : {"${group}" = members}]
-    )
+    groups_data = local.groups_computed == null ? null : [
+        for group in local.groups_computed : {"${group}" = []}
+    ]
 
     cloud_config_data = merge(
         {

--- a/terraform/module/proxmox/cloud_config/variable.tf
+++ b/terraform/module/proxmox/cloud_config/variable.tf
@@ -78,7 +78,7 @@ variable "users" {
 
 variable "groups" {
     # https://cloudinit.readthedocs.io/en/latest/reference/modules.html#users-and-groups
-    type = any # Accept either a map of groups to members or a simple list of groups
+    type = list(string)
     default = null
 }
 

--- a/terraform/module/proxmox/virtual_machine/main.tf
+++ b/terraform/module/proxmox/virtual_machine/main.tf
@@ -34,9 +34,7 @@ module "cloud_config" {
             lock_passwd = false,
         }
     ]
-    groups = {
-        docker = []
-    }
+    groups = ["docker"]
     gitconfig = {
         username = "nodadyoushutup"
         email = "admin@nodadyoushutup.com"


### PR DESCRIPTION
## Summary
- simplify groups input in cloud config module to be a list of strings
- update local logic to reflect the simplified type
- adjust virtual machine example to pass a list

## Testing
- `terraform init` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ac292641c832cacc167a543c208bf