### PR TITLE
Fix cloud config merge logic

### DIFF
--- a/terraform/module/proxmox/cloud_config/local.tf
+++ b/terraform/module/proxmox/cloud_config/local.tf
@@ -145,20 +145,14 @@ locals { # Logic
 }
 
 locals { # Template
-    additional_objects = [
-        for obj in [
-            local.mounts_object,
-            local.groups_object,
-            local.write_files_object,
-            local.runcmd_object
-        ] : obj if obj != null
-    ]
-
     cloud_config_data = merge(
         local.bootcmd_object,
         local.hostname_object,
         local.users_object,
-        length(local.additional_objects) > 0 ? merge(local.additional_objects...) : {}
+        local.mounts_object != null ? local.mounts_object : {},
+        local.groups_object != null ? local.groups_object : {},
+        local.write_files_object != null ? local.write_files_object : {},
+        local.runcmd_object != null ? local.runcmd_object : {},
     )
 
     cloud_config_yaml = "#cloud-config\n${yamlencode(local.cloud_config_data)}"


### PR DESCRIPTION
## Summary
- simplify additional objects merge logic for cloud-config to avoid inconsistent type errors

## Testing
- `terraform fmt -check` *(fails: terraform not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686ac721c998832c99dd2bc55d28eff1