### PR TITLE
Adjust network defaults in cloud config generation

### DIFF
--- a/terraform/module/proxmox/cloud_config/local.tf
+++ b/terraform/module/proxmox/cloud_config/local.tf
@@ -158,10 +158,10 @@ locals { # Logic
     }
 
     ipv4_address_object = local.ipv4_computed.address != null && local.ipv4_computed.address != "dhcp" ? {
-        dhcp4    = false
+        dhcp4    = "no"
         addresses = ["${local.ipv4_computed.address}/24"]
     } : {
-        dhcp4 = true
+        dhcp4 = "yes"
     }
 
     ipv4_gateway_object = (local.ipv4_computed.address != null && local.ipv4_computed.address != "dhcp" && local.ipv4_computed.gateway != null) ? {

--- a/terraform/module/proxmox/cloud_config/template/network_config.yaml.tpl
+++ b/terraform/module/proxmox/cloud_config/template/network_config.yaml.tpl
@@ -8,13 +8,13 @@ network:
       set-name: eth0
       %{ if ipv4.address != "dhcp"}
       dhcp4: no
-      addresses: 
+      addresses:
       - ${ipv4.address}/24
       %{ if ipv4.gateway != null}
       gateway4: ${ipv4.gateway}
       %{ endif }
       %{ else }
-      dhcp4: true
+      dhcp4: yes
       %{ endif }
       nameservers:
         addresses: 


### PR DESCRIPTION
## Summary
- update auto-generated network settings to align with the new schema
- switch network template's DHCP values to `yes`/`no`

## Testing
- `terraform fmt -recursive` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ad653e498832cb68644b6849da642