### PR TITLE
Fix network config type mismatch

### DIFF
--- a/terraform/module/proxmox/cloud_config/local.tf
+++ b/terraform/module/proxmox/cloud_config/local.tf
@@ -162,7 +162,6 @@ locals { # Logic
         addresses = ["${local.ipv4_computed.address}/24"]
     } : {
         dhcp4 = "yes"
-        addresses = null
     }
 
     ipv4_gateway_object = (local.ipv4_computed.address != null && local.ipv4_computed.address != "dhcp" && local.ipv4_computed.gateway != null) ? {
@@ -188,7 +187,9 @@ locals { # Logic
         }
     }
 
-    network_object = local.network_computed != null ? local.network_computed : local.network_generated_object
+    network_object = local.network_computed != null ?
+        local.network_computed :
+        jsondecode(jsonencode(local.network_generated_object))
 }
 
 locals { # Template


### PR DESCRIPTION
## Summary
- ensure IPv4 address object doesn't return null list
- cast generated network object to dynamic to satisfy type checks

## Testing
- `terraform version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_686ada4daf00832c9bdaa94342ca30b3