### PR TITLE
Fix terraform cloud_init_network lookups

### DIFF
--- a/terraform/module/proxmox/cloud_init_network/computed.tf
+++ b/terraform/module/proxmox/cloud_init_network/computed.tf
@@ -14,8 +14,8 @@ locals { # Computed
     ethernets_computed = length(local.ethernet_names) > 0 ? {
         for name in local.ethernet_names :
         name => merge(
-            lookup(local.ethernets_global != null ? local.ethernets_global : {}, name, {}),
-            lookup(local.ethernets_input  != null ? local.ethernets_input  : {}, name, {})
+            local.ethernets_global != null ? lookup(local.ethernets_global, name, {}) : {},
+            local.ethernets_input  != null ? lookup(local.ethernets_input,  name, {}) : {}
         )
     } : null
 


### PR DESCRIPTION
## Summary
- fix lookup defaults for empty ethernet maps

## Testing
- `terraform version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d1cbc0684832c999afe51d4af4c62