### PR TITLE
Fix lookup default type in network module

### DIFF
--- a/terraform/module/proxmox/cloud_init_network/computed.tf
+++ b/terraform/module/proxmox/cloud_init_network/computed.tf
@@ -14,8 +14,8 @@ locals { # Computed
     ethernets_computed = length(local.ethernet_names) > 0 ? {
         for name in local.ethernet_names :
         name => merge(
-            local.ethernets_global != null ? lookup(local.ethernets_global, name, {}) : {},
-            local.ethernets_input  != null ? lookup(local.ethernets_input,  name, {}) : {}
+            local.ethernets_global != null ? coalesce(lookup(local.ethernets_global, name, null), {}) : {},
+            local.ethernets_input  != null ? coalesce(lookup(local.ethernets_input,  name, null),  {}) : {}
         )
     } : null
 


### PR DESCRIPTION
## Summary
- ensure `lookup` default matches map element type in computed networking locals

## Testing
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687d1daab0a8832cbca387769009963f