### PR TITLE
Fix ethernet default object for Terraform module

### DIFF
--- a/terraform/module/proxmox/cloud_init_network/computed.tf
+++ b/terraform/module/proxmox/cloud_init_network/computed.tf
@@ -1,38 +1,48 @@
 locals { # Computed
-    # PROXMOX
-    datastore_id_computed = local.datastore_id_input != null ? local.datastore_id_input : local.datastore_id_global != null ? local.datastore_id_global : null
-    node_name_computed = local.node_name_input != null ? local.node_name_input : local.node_name_global != null ? local.node_name_global : null
-    overwrite_computed = local.overwrite_input != null ? local.overwrite_input : local.overwrite_global != null ? local.overwrite_global : null
+  # PROXMOX
+  datastore_id_computed = local.datastore_id_input != null ? local.datastore_id_input : local.datastore_id_global != null ? local.datastore_id_global : null
+  node_name_computed    = local.node_name_input != null ? local.node_name_input : local.node_name_global != null ? local.node_name_global : null
+  overwrite_computed    = local.overwrite_input != null ? local.overwrite_input : local.overwrite_global != null ? local.overwrite_global : null
 
-    # NETWORK
-    # Union of interface names defined via globals or input
-    ethernet_names = distinct(concat(
-        local.ethernets_global != null ? keys(local.ethernets_global) : [],
-        local.ethernets_input  != null ? keys(local.ethernets_input)  : [],
-    ))
+  # Default object for ethernet configuration
+  ethernet_default = {
+    match       = null
+    set_name    = null
+    dhcp4       = null
+    addresses   = null
+    gateway4    = null
+    nameservers = null
+  }
 
-    ethernets_computed = length(local.ethernet_names) > 0 ? {
-        for name in local.ethernet_names :
-        name => merge(
-            local.ethernets_global != null ? lookup(local.ethernets_global, name, {}) : {},
-            local.ethernets_input  != null ? lookup(local.ethernets_input,  name, {}) : {}
-        )
-    } : null
+  # NETWORK
+  # Union of interface names defined via globals or input
+  ethernet_names = distinct(concat(
+    local.ethernets_global != null ? keys(local.ethernets_global) : [],
+    local.ethernets_input != null ? keys(local.ethernets_input) : [],
+  ))
 
-    bonds_computed   = local.bonds_input != null ? local.bonds_input : local.bonds_global
-    bridges_computed = local.bridges_input != null ? local.bridges_input : local.bridges_global
-    vlans_computed   = local.vlans_input != null ? local.vlans_input : local.vlans_global
-
-    ethernets_clean = local.ethernets_computed != null ? {
-        for n, cfg in local.ethernets_computed :
-        n => { for k, v in cfg : k => v if v != null }
-    } : null
-
-    network_computed = merge(
-        { version = 2 },
-        local.ethernets_clean != null ? { ethernets = local.ethernets_clean } : {},
-        local.bonds_computed != null ? { bonds = local.bonds_computed } : {},
-        local.bridges_computed != null ? { bridges = local.bridges_computed } : {},
-        local.vlans_computed != null ? { vlans = local.vlans_computed } : {}
+  ethernets_computed = length(local.ethernet_names) > 0 ? {
+    for name in local.ethernet_names :
+    name => merge(
+      local.ethernets_global != null ? lookup(local.ethernets_global, name, local.ethernet_default) : local.ethernet_default,
+      local.ethernets_input != null ? lookup(local.ethernets_input, name, local.ethernet_default) : local.ethernet_default
     )
+  } : null
+
+  bonds_computed   = local.bonds_input != null ? local.bonds_input : local.bonds_global
+  bridges_computed = local.bridges_input != null ? local.bridges_input : local.bridges_global
+  vlans_computed   = local.vlans_input != null ? local.vlans_input : local.vlans_global
+
+  ethernets_clean = local.ethernets_computed != null ? {
+    for n, cfg in local.ethernets_computed :
+    n => { for k, v in cfg : k => v if v != null }
+  } : null
+
+  network_computed = merge(
+    { version = 2 },
+    local.ethernets_clean != null ? { ethernets = local.ethernets_clean } : {},
+    local.bonds_computed != null ? { bonds = local.bonds_computed } : {},
+    local.bridges_computed != null ? { bridges = local.bridges_computed } : {},
+    local.vlans_computed != null ? { vlans = local.vlans_computed } : {}
+  )
 }


### PR DESCRIPTION
## Summary
- ensure the default object used in `lookup` for ethernets has the right shape

## Testing
- `terraform fmt terraform/module/proxmox/cloud_init_network/computed.tf`
- `terraform init -input=false -backend=false` *(fails: could not query providers)*

------
https://chatgpt.com/codex/tasks/task_e_687d2241e854832ca8998fbd138a00e1