### PR TITLE
Loop debug machines from config

### DIFF
--- a/terraform/job/debug/main.tf
+++ b/terraform/job/debug/main.tf
@@ -1,60 +1,35 @@
+locals {
+  machines = { for k, v in try(local.config.proxmox.machine, []) : k => v }
+}
+
 module "virtual_machine" {
-  source = "../../module/proxmox/virtual_machine"
+  for_each = local.machines
+  source   = "../../module/proxmox/virtual_machine"
 
   config = local.config
-  vm_id  = 2000
 
-  cloud_init = {
-    config       = local.config
-    name         = "test"
-    datastore_id = "config"
-    node_name    = "pve"
-    overwrite    = true
-
-    network = {
-      ethernets = {
-        eth0 = {
-          match = {
-            name = "en*"
-          }
-          set-name  = "eth0"
-          dhcp4     = false
-          addresses = ["192.168.1.185/24"]
-          gateway4  = "192.168.1.1"
-          nameservers = {
-            addresses = ["8.8.8.8", "8.8.4.4"]
-          }
-        }
-      }
-    }
-
-    bootcmd = ["mkdir -p /mnt/epool/media"]
-    runcmd  = ["echo 'runcmd test'"]
-    mounts  = [["192.168.1.100:/mnt/epool/media", "/mnt/epool/media", "nfs", "defaults,_netdev", "0", "0"]]
-    users = [{
-      name              = "nodadyoushutup"
-      groups            = ["sudo", "docker"]
-      ssh_import_id     = ["gh:nodadyoushutup"]
-      shell             = "/bin/bash"
-      sudo              = "ALL=(ALL) NOPASSWD:ALL"
-      plain_text_passwd = "password"
-      lock_passwd       = false
-    }]
-    groups = ["docker"]
-    gitconfig = {
-      username   = "nodadyoushutup"
-      email      = "admin@nodadyoushutup.com"
-      github_pat = local.config.proxmox.global.machine.cloud_config.gitconfig.github_pat
-    }
-    write_files = [{
-      path        = "/etc/skel/.canary"
-      encoding    = "b64"
-      content     = "Y2FuYXJ5Cg=="
-      permissions = "0640"
-    }]
-  }
+  cloud_init       = try(each.value.cloud_init, null)
+  agent            = try(each.value.agent, null)
+  audio_device     = try(each.value.audio_device, null)
+  bios             = try(each.value.bios, null)
+  boot_order       = try(each.value.boot_order, null)
+  cpu              = try(each.value.cpu, null)
+  description      = try(each.value.description, null)
+  disk             = try(each.value.disk, null)
+  machine          = try(each.value.machine, null)
+  memory           = try(each.value.memory, null)
+  network_device   = try(each.value.network_device, null)
+  node_name        = try(each.value.node_name, null)
+  on_boot          = try(each.value.on_boot, null)
+  operating_system = try(each.value.operating_system, null)
+  started          = try(each.value.started, null)
+  startup          = try(each.value.startup, null)
+  tags             = try(each.value.tags, null)
+  stop_on_destroy  = try(each.value.stop_on_destroy, null)
+  vga              = try(each.value.vga, null)
+  vm_id            = try(each.value.vm_id, null)
 }
 
 output "virtual_machine" {
-  value = module.virtual_machine.debug
+  value = { for k, m in module.virtual_machine : k => m.debug }
 }


### PR DESCRIPTION
## Summary
- generate virtual machines in the debug job by iterating over the machines defined in the configuration

## Testing
- `terraform init -backend=false` *(fails: could not connect to registry.terraform.io)*
- `terraform validate` *(fails: missing required provider)*

------
https://chatgpt.com/codex/tasks/task_e_687d60e39ed8832cabf97473e5cf2521