### PR TITLE
Fix user type mismatch

### DIFF
--- a/terraform/module/proxmox/cloud_init_user/computed.tf
+++ b/terraform/module/proxmox/cloud_init_user/computed.tf
@@ -1,19 +1,24 @@
 locals { # Computed
-    # PROXMOX
-    datastore_id_computed = local.datastore_id_input != null ? local.datastore_id_input : local.datastore_id_global != null ? local.datastore_id_global : null
-    node_name_computed = local.node_name_input != null ? local.node_name_input : local.node_name_global != null ? local.node_name_global : null
-    overwrite_computed = local.overwrite_input != null ? local.overwrite_input : local.overwrite_global != null ? local.overwrite_global : null
+  # PROXMOX
+  datastore_id_computed = local.datastore_id_input != null ? local.datastore_id_input : local.datastore_id_global != null ? local.datastore_id_global : null
+  node_name_computed    = local.node_name_input != null ? local.node_name_input : local.node_name_global != null ? local.node_name_global : null
+  overwrite_computed    = local.overwrite_input != null ? local.overwrite_input : local.overwrite_global != null ? local.overwrite_global : null
 
-    # USER
-    users_computed = local.users_input != null ? local.users_input : local.users_global != null ? local.users_global : [] # Must be empty list to satisfy length() check in object
-    mounts_computed = local.mounts_input != null ? local.mounts_input : local.mounts_global != null ? local.mounts_global : null
-    groups_computed = local.groups_input != null ? local.groups_input : local.groups_global != null ? local.groups_global : null
-    gitconfig_computed = {
-        username = local.gitconfig_input.username != null ? local.gitconfig_input.username : local.gitconfig_global.username != null ? local.gitconfig_global.username : null
-        email = local.gitconfig_input.email != null ? local.gitconfig_input.email : local.gitconfig_global.email != null ? local.gitconfig_global.email : null
-        github_pat = local.gitconfig_input.github_pat != null ? local.gitconfig_input.github_pat : local.gitconfig_global.github_pat != null ? local.gitconfig_global.github_pat : null
-    }
-    bootcmd_computed = local.bootcmd_input != null ? local.bootcmd_input : local.bootcmd_global != null ? local.bootcmd_global : [] # Must be empty list to satisfy length() check in object
-    runcmd_computed = local.runcmd_input != null ? local.runcmd_input : local.runcmd_global != null ? local.runcmd_global : [] # Must be empty list to satisfy length() check in object
-    write_files_computed = local.write_files_input != null ? local.write_files_input : local.write_files_global != null ? local.write_files_global : null
+  # USER
+  users_global_typed = local.users_global != null ? [
+    for u in local.users_global :
+    merge(local.user_default, u)
+  ] : null
+
+  users_computed  = local.users_input != null ? local.users_input : local.users_global_typed != null ? local.users_global_typed : [] # Must be empty list to satisfy length() check in object
+  mounts_computed = local.mounts_input != null ? local.mounts_input : local.mounts_global != null ? local.mounts_global : null
+  groups_computed = local.groups_input != null ? local.groups_input : local.groups_global != null ? local.groups_global : null
+  gitconfig_computed = {
+    username   = local.gitconfig_input.username != null ? local.gitconfig_input.username : local.gitconfig_global.username != null ? local.gitconfig_global.username : null
+    email      = local.gitconfig_input.email != null ? local.gitconfig_input.email : local.gitconfig_global.email != null ? local.gitconfig_global.email : null
+    github_pat = local.gitconfig_input.github_pat != null ? local.gitconfig_input.github_pat : local.gitconfig_global.github_pat != null ? local.gitconfig_global.github_pat : null
+  }
+  bootcmd_computed     = local.bootcmd_input != null ? local.bootcmd_input : local.bootcmd_global != null ? local.bootcmd_global : [] # Must be empty list to satisfy length() check in object
+  runcmd_computed      = local.runcmd_input != null ? local.runcmd_input : local.runcmd_global != null ? local.runcmd_global : []     # Must be empty list to satisfy length() check in object
+  write_files_computed = local.write_files_input != null ? local.write_files_input : local.write_files_global != null ? local.write_files_global : null
 }

--- a/terraform/module/proxmox/cloud_init_user/constant.tf
+++ b/terraform/module/proxmox/cloud_init_user/constant.tf
@@ -1,6 +1,34 @@
 locals { # Constant
-    source = {
-        talos    = "${path.module}/template/talos_config.yaml.tpl"
-        gitconfig = "${path.module}/template/gitconfig.tpl"
-    }
+  source = {
+    talos     = "${path.module}/template/talos_config.yaml.tpl"
+    gitconfig = "${path.module}/template/gitconfig.tpl"
+  }
+
+  user_default = {
+    name                = null
+    doas                = null
+    expiredate          = null
+    gecos               = null
+    groups              = null
+    homedir             = null
+    inactive            = null
+    lock_passwd         = null
+    no_create_home      = null
+    no_log_init         = null
+    no_user_group       = null
+    passwd              = null
+    hashed_passwd       = null
+    plain_text_passwd   = null
+    create_groups       = null
+    primary_group       = null
+    selinux_user        = null
+    shell               = null
+    snapuser            = null
+    ssh_authorized_keys = null
+    ssh_import_id       = null
+    ssh_redirect_user   = null
+    system              = null
+    sudo                = null
+    uid                 = null
+  }
 }


### PR DESCRIPTION
## Summary
- ensure a default user object is defined
- compute typed user entries
- use typed list when generating users

## Testing
- `terraform fmt terraform/module/proxmox/cloud_init_user/computed.tf terraform/module/proxmox/cloud_init_user/constant.tf`
- `terraform init -backend=false` *(fails: could not connect to registry.terraform.io)*

------
https://chatgpt.com/codex/tasks/task_e_687d6854f2cc832cac178e422d028766