### PR TITLE
Refactor VM module for optional object configs

### DIFF
--- a/terraform/module/proxmox/virtual_machine/computed.tf
+++ b/terraform/module/proxmox/virtual_machine/computed.tf
@@ -1,93 +1,93 @@
 locals {
-    agent_computed = {
-        enabled = local.agent_input.enabled != null ? local.agent_input.enabled : local.agent_global.enabled != null ? local.agent_global.enabled : null
-        timeout = local.agent_input.timeout != null ? local.agent_input.timeout : local.agent_global.timeout != null ? local.agent_global.timeout : null
-        trim = local.agent_input.trim != null ? local.agent_input.trim : local.agent_global.trim != null ? local.agent_global.trim : null
-        type = local.agent_input.type != null ? local.agent_input.type : local.agent_global.type != null ? local.agent_global.type : null
-    }
+  agent_computed = try(local.agent_input, null) != null || try(local.agent_global, null) != null ? {
+    enabled = local.agent_input.enabled != null ? local.agent_input.enabled : local.agent_global.enabled != null ? local.agent_global.enabled : null
+    timeout = local.agent_input.timeout != null ? local.agent_input.timeout : local.agent_global.timeout != null ? local.agent_global.timeout : null
+    trim    = local.agent_input.trim != null ? local.agent_input.trim : local.agent_global.trim != null ? local.agent_global.trim : null
+    type    = local.agent_input.type != null ? local.agent_input.type : local.agent_global.type != null ? local.agent_global.type : null
+  } : null
 
-    audio_device_computed = try(local.audio_device_input, null) != null || try(local.audio_device_global, null) != null ? {
-        device = try(local.audio_device_input.device, null) != null ? try(local.audio_device_input.device, null) : try(local.audio_device_global.device, null) != null ? try(local.audio_device_global.device, null) : null
-        driver = try(local.audio_device_input.driver, null) != null ? try(local.audio_device_input.driver, null) : try(local.audio_device_global.driver, null) != null ? try(local.audio_device_global.driver, null) : null
-        enabled = try(local.audio_device_input.enabled, null) != null ? try(local.audio_device_input.enabled, null) : try(local.audio_device_global.enabled, null) != null ? try(local.audio_device_global.enabled, null) : null
-    } : null
+  audio_device_computed = try(local.audio_device_input, null) != null || try(local.audio_device_global, null) != null ? {
+    device  = try(local.audio_device_input.device, null) != null ? try(local.audio_device_input.device, null) : try(local.audio_device_global.device, null) != null ? try(local.audio_device_global.device, null) : null
+    driver  = try(local.audio_device_input.driver, null) != null ? try(local.audio_device_input.driver, null) : try(local.audio_device_global.driver, null) != null ? try(local.audio_device_global.driver, null) : null
+    enabled = try(local.audio_device_input.enabled, null) != null ? try(local.audio_device_input.enabled, null) : try(local.audio_device_global.enabled, null) != null ? try(local.audio_device_global.enabled, null) : null
+  } : null
 
-    bios_computed = local.bios_input != null ? local.bios_input : local.bios_global != null ? local.bios_global : null
+  bios_computed = local.bios_input != null ? local.bios_input : local.bios_global != null ? local.bios_global : null
 
-    boot_order_computed = local.boot_order_input != null ? local.boot_order_input : local.boot_order_global != null ? local.boot_order_global : null
+  boot_order_computed = local.boot_order_input != null ? local.boot_order_input : local.boot_order_global != null ? local.boot_order_global : null
 
-    cpu_computed = {
-        affinity = local.cpu_input.affinity != null ? local.cpu_input.affinity : local.cpu_global.affinity != null ? local.cpu_global.affinity : null
-        cores = local.cpu_input.cores != null ? local.cpu_input.cores : local.cpu_global.cores != null ? local.cpu_global.cores : null
-        flags = local.cpu_input.flags != null ? local.cpu_input.flags : local.cpu_global.flags != null ? local.cpu_global.flags : null
-        hotplugged = local.cpu_input.hotplugged != null ? local.cpu_input.hotplugged : local.cpu_global.hotplugged != null ? local.cpu_global.hotplugged : null
-        limit = local.cpu_input.limit != null ? local.cpu_input.limit : local.cpu_global.limit != null ? local.cpu_global.limit : null
-        numa = local.cpu_input.numa != null ? local.cpu_input.numa : local.cpu_global.numa != null ? local.cpu_global.numa : null
-        sockets = local.cpu_input.sockets != null ? local.cpu_input.sockets : local.cpu_global.sockets != null ? local.cpu_global.sockets : null
-        type = local.cpu_input.type != null ? local.cpu_input.type : local.cpu_global.type != null ? local.cpu_global.type : null
-        units = local.cpu_input.units != null ? local.cpu_input.units : local.cpu_global.units != null ? local.cpu_global.units : null
-    }
+  cpu_computed = try(local.cpu_input, null) != null || try(local.cpu_global, null) != null ? {
+    affinity   = local.cpu_input.affinity != null ? local.cpu_input.affinity : local.cpu_global.affinity != null ? local.cpu_global.affinity : null
+    cores      = local.cpu_input.cores != null ? local.cpu_input.cores : local.cpu_global.cores != null ? local.cpu_global.cores : null
+    flags      = local.cpu_input.flags != null ? local.cpu_input.flags : local.cpu_global.flags != null ? local.cpu_global.flags : null
+    hotplugged = local.cpu_input.hotplugged != null ? local.cpu_input.hotplugged : local.cpu_global.hotplugged != null ? local.cpu_global.hotplugged : null
+    limit      = local.cpu_input.limit != null ? local.cpu_input.limit : local.cpu_global.limit != null ? local.cpu_global.limit : null
+    numa       = local.cpu_input.numa != null ? local.cpu_input.numa : local.cpu_global.numa != null ? local.cpu_global.numa : null
+    sockets    = local.cpu_input.sockets != null ? local.cpu_input.sockets : local.cpu_global.sockets != null ? local.cpu_global.sockets : null
+    type       = local.cpu_input.type != null ? local.cpu_input.type : local.cpu_global.type != null ? local.cpu_global.type : null
+    units      = local.cpu_input.units != null ? local.cpu_input.units : local.cpu_global.units != null ? local.cpu_global.units : null
+  } : null
 
-    description_computed = local.description_input != null ? local.description_input : local.description_global != null ? local.description_global : null
+  description_computed = local.description_input != null ? local.description_input : local.description_global != null ? local.description_global : null
 
-    disk_computed = local.disk_input != null || local.disk_global != null ? {
-        aio = local.disk_input.aio != null ? local.disk_input.aio : local.disk_global.aio != null ? local.disk_global.aio : null
-        backup = local.disk_input.backup != null ? local.disk_input.backup : local.disk_global.backup != null ? local.disk_global.backup : null
-        cache = local.disk_input.cache != null ? local.disk_input.cache : local.disk_global.cache != null ? local.disk_global.cache : null
-        datastore_id = local.disk_input.datastore_id != null ? local.disk_input.datastore_id : local.disk_global.datastore_id != null ? local.disk_global.datastore_id : null
-        discard = local.disk_input.discard != null ? local.disk_input.discard : local.disk_global.discard != null ? local.disk_global.discard : null
-        file_format = local.disk_input.file_format != null ? local.disk_input.file_format : local.disk_global.file_format != null ? local.disk_global.file_format : null
-        file_id = local.disk_input.file_id != null ? local.disk_input.file_id : local.disk_global.file_id != null ? local.disk_global.file_id : module.image.image_id
-        interface = local.disk_input.interface != null ? local.disk_input.interface : local.disk_global.interface != null ? local.disk_global.interface : null
-        iothread = local.disk_input.iothread != null ? local.disk_input.iothread : local.disk_global.iothread != null ? local.disk_global.iothread : null
-        replicate = local.disk_input.replicate != null ? local.disk_input.replicate : local.disk_global.replicate != null ? local.disk_global.replicate : null
-        serial = local.disk_input.serial != null ? local.disk_input.serial : local.disk_global.serial != null ? local.disk_global.serial : null
-        size = local.disk_input.size != null ? local.disk_input.size : local.disk_global.size != null ? local.disk_global.size : 20
-        ssd = local.disk_input.ssd != null ? local.disk_input.ssd : local.disk_global.ssd != null ? local.disk_global.ssd : null
-    } : null
+  disk_computed = local.disk_input != null || local.disk_global != null ? {
+    aio          = local.disk_input.aio != null ? local.disk_input.aio : local.disk_global.aio != null ? local.disk_global.aio : null
+    backup       = local.disk_input.backup != null ? local.disk_input.backup : local.disk_global.backup != null ? local.disk_global.backup : null
+    cache        = local.disk_input.cache != null ? local.disk_input.cache : local.disk_global.cache != null ? local.disk_global.cache : null
+    datastore_id = local.disk_input.datastore_id != null ? local.disk_input.datastore_id : local.disk_global.datastore_id != null ? local.disk_global.datastore_id : null
+    discard      = local.disk_input.discard != null ? local.disk_input.discard : local.disk_global.discard != null ? local.disk_global.discard : null
+    file_format  = local.disk_input.file_format != null ? local.disk_input.file_format : local.disk_global.file_format != null ? local.disk_global.file_format : null
+    file_id      = local.disk_input.file_id != null ? local.disk_input.file_id : local.disk_global.file_id != null ? local.disk_global.file_id : module.image.image_id
+    interface    = local.disk_input.interface != null ? local.disk_input.interface : local.disk_global.interface != null ? local.disk_global.interface : null
+    iothread     = local.disk_input.iothread != null ? local.disk_input.iothread : local.disk_global.iothread != null ? local.disk_global.iothread : null
+    replicate    = local.disk_input.replicate != null ? local.disk_input.replicate : local.disk_global.replicate != null ? local.disk_global.replicate : null
+    serial       = local.disk_input.serial != null ? local.disk_input.serial : local.disk_global.serial != null ? local.disk_global.serial : null
+    size         = local.disk_input.size != null ? local.disk_input.size : local.disk_global.size != null ? local.disk_global.size : 20
+    ssd          = local.disk_input.ssd != null ? local.disk_input.ssd : local.disk_global.ssd != null ? local.disk_global.ssd : null
+  } : null
 
-    machine_computed = local.machine_input != null ? local.machine_input : local.machine_global != null ? local.machine_global : null
+  machine_computed = local.machine_input != null ? local.machine_input : local.machine_global != null ? local.machine_global : null
 
-    memory_computed = {
-        dedicated = local.memory_input.dedicated != null ? local.memory_input.dedicated : local.memory_global.dedicated != null ? local.memory_global.dedicated : null
-        floating = local.memory_input.floating != null ? local.memory_input.floating : local.memory_global.floating != null ? local.memory_global.floating : null
-        shared = local.memory_input.shared != null ? local.memory_input.shared : local.memory_global.shared != null ? local.memory_global.shared : null
-    }
+  memory_computed = try(local.memory_input, null) != null || try(local.memory_global, null) != null ? {
+    dedicated = local.memory_input.dedicated != null ? local.memory_input.dedicated : local.memory_global.dedicated != null ? local.memory_global.dedicated : null
+    floating  = local.memory_input.floating != null ? local.memory_input.floating : local.memory_global.floating != null ? local.memory_global.floating : null
+    shared    = local.memory_input.shared != null ? local.memory_input.shared : local.memory_global.shared != null ? local.memory_global.shared : null
+  } : null
 
-    network_device_computed = {
-        bridge = local.network_device_input.bridge != null ? local.network_device_input.bridge : local.network_device_global.bridge != null ? local.network_device_global.bridge : null
-        disconnected = local.network_device_input.disconnected != null ? local.network_device_input.disconnected : local.network_device_global.disconnected != null ? local.network_device_global.disconnected : null
-        enabled = local.network_device_input.enabled != null ? local.network_device_input.enabled : local.network_device_global.enabled != null ? local.network_device_global.enabled : null
-        firewall = local.network_device_input.firewall != null ? local.network_device_input.firewall : local.network_device_global.firewall != null ? local.network_device_global.firewall : null
-        mac_address = local.network_device_input.mac_address != null ? local.network_device_input.mac_address : local.network_device_global.mac_address != null ? local.network_device_global.mac_address : null
-        model = local.network_device_input.model != null ? local.network_device_input.model : local.network_device_global.model != null ? local.network_device_global.model : null
-    }
+  network_device_computed = try(local.network_device_input, null) != null || try(local.network_device_global, null) != null ? {
+    bridge       = local.network_device_input.bridge != null ? local.network_device_input.bridge : local.network_device_global.bridge != null ? local.network_device_global.bridge : null
+    disconnected = local.network_device_input.disconnected != null ? local.network_device_input.disconnected : local.network_device_global.disconnected != null ? local.network_device_global.disconnected : null
+    enabled      = local.network_device_input.enabled != null ? local.network_device_input.enabled : local.network_device_global.enabled != null ? local.network_device_global.enabled : null
+    firewall     = local.network_device_input.firewall != null ? local.network_device_input.firewall : local.network_device_global.firewall != null ? local.network_device_global.firewall : null
+    mac_address  = local.network_device_input.mac_address != null ? local.network_device_input.mac_address : local.network_device_global.mac_address != null ? local.network_device_global.mac_address : null
+    model        = local.network_device_input.model != null ? local.network_device_input.model : local.network_device_global.model != null ? local.network_device_global.model : null
+  } : null
 
-    node_name_computed = local.node_name_input != null ? local.node_name_input : local.node_name_global != null ? local.node_name_global : null
+  node_name_computed = local.node_name_input != null ? local.node_name_input : local.node_name_global != null ? local.node_name_global : null
 
-    on_boot_computed = local.on_boot_input != null ? local.on_boot_input : local.on_boot_global != null ? local.on_boot_global : null
+  on_boot_computed = local.on_boot_input != null ? local.on_boot_input : local.on_boot_global != null ? local.on_boot_global : null
 
-    operating_system_computed = {
-        type = local.operating_system_input.type != null ? local.operating_system_input.type : local.operating_system_global.type != null ? local.operating_system_global.type : null
-    }
+  operating_system_computed = try(local.operating_system_input, null) != null || try(local.operating_system_global, null) != null ? {
+    type = local.operating_system_input.type != null ? local.operating_system_input.type : local.operating_system_global.type != null ? local.operating_system_global.type : null
+  } : null
 
-    started_computed = local.started_input != null ? local.started_input : local.started_global != null ? local.started_global : null
+  started_computed = local.started_input != null ? local.started_input : local.started_global != null ? local.started_global : null
 
-    startup_computed = {
-        order = local.startup_input.order != null ? local.startup_input.order : local.startup_global.order != null ? local.startup_global.order : null
-        up_delay = local.startup_input.up_delay != null ? local.startup_input.up_delay : local.startup_global.up_delay != null ? local.startup_global.up_delay : null
-        down_delay = local.startup_input.down_delay != null ? local.startup_input.down_delay : local.startup_global.down_delay != null ? local.startup_global.down_delay : null
-    }
+  startup_computed = try(local.startup_input, null) != null || try(local.startup_global, null) != null ? {
+    order      = local.startup_input.order != null ? local.startup_input.order : local.startup_global.order != null ? local.startup_global.order : null
+    up_delay   = local.startup_input.up_delay != null ? local.startup_input.up_delay : local.startup_global.up_delay != null ? local.startup_global.up_delay : null
+    down_delay = local.startup_input.down_delay != null ? local.startup_input.down_delay : local.startup_global.down_delay != null ? local.startup_global.down_delay : null
+  } : null
 
-    tags_computed = local.tags_input != null ? local.tags_input : local.tags_global != null ? local.tags_global : null
+  tags_computed = local.tags_input != null ? local.tags_input : local.tags_global != null ? local.tags_global : null
 
-    stop_on_destroy_computed = local.stop_on_destroy_input != null ? local.stop_on_destroy_input : local.stop_on_destroy_global != null ? local.stop_on_destroy_global : null
+  stop_on_destroy_computed = local.stop_on_destroy_input != null ? local.stop_on_destroy_input : local.stop_on_destroy_global != null ? local.stop_on_destroy_global : null
 
-    vga_computed = {
-        memory = local.vga_input.memory != null ? local.vga_input.memory : local.vga_global.memory != null ? local.vga_global.memory : null
-        type = local.vga_input.type != null ? local.vga_input.type : local.vga_global.type != null ? local.vga_global.type : null
-        clipboard = local.vga_input.clipboard != null ? local.vga_input.clipboard : local.vga_global.clipboard != null ? local.vga_global.clipboard : null
-    }
-        
-    vm_id_computed = local.vm_id_input != null ? local.vm_id_input : null # No global available
+  vga_computed = try(local.vga_input, null) != null || try(local.vga_global, null) != null ? {
+    memory    = local.vga_input.memory != null ? local.vga_input.memory : local.vga_global.memory != null ? local.vga_global.memory : null
+    type      = local.vga_input.type != null ? local.vga_input.type : local.vga_global.type != null ? local.vga_global.type : null
+    clipboard = local.vga_input.clipboard != null ? local.vga_input.clipboard : local.vga_global.clipboard != null ? local.vga_global.clipboard : null
+  } : null
+
+  vm_id_computed = local.vm_id_input != null ? local.vm_id_input : null # No global available
 }

--- a/terraform/module/proxmox/virtual_machine/global.tf
+++ b/terraform/module/proxmox/virtual_machine/global.tf
@@ -1,91 +1,91 @@
 locals {
-    agent_global = {
-        enabled = try(var.config.proxmox.global.virtual_machine.agent.enabled, null)
-        timeout = try(var.config.proxmox.global.virtual_machine.agent.timeout, null)
-        trim = try(var.config.proxmox.global.virtual_machine.agent.trim, null)
-        type = try(var.config.proxmox.global.virtual_machine.agent.type, null)
-    }
+  agent_global = try(var.config.proxmox.global.virtual_machine.agent, null) != null ? {
+    enabled = try(var.config.proxmox.global.virtual_machine.agent.enabled, null)
+    timeout = try(var.config.proxmox.global.virtual_machine.agent.timeout, null)
+    trim    = try(var.config.proxmox.global.virtual_machine.agent.trim, null)
+    type    = try(var.config.proxmox.global.virtual_machine.agent.type, null)
+  } : null
 
-    audio_device_global = try(var.config.proxmox.global.virtual_machine.audio_device, null) != null ? {
-        device = try(var.config.proxmox.global.virtual_machine.audio_device.device, null)
-        driver = try(var.config.proxmox.global.virtual_machine.audio_device.driver, null)
-        enabled = try(var.config.proxmox.global.virtual_machine.audio_device.enabled, null)
-    } : null
+  audio_device_global = try(var.config.proxmox.global.virtual_machine.audio_device, null) != null ? {
+    device  = try(var.config.proxmox.global.virtual_machine.audio_device.device, null)
+    driver  = try(var.config.proxmox.global.virtual_machine.audio_device.driver, null)
+    enabled = try(var.config.proxmox.global.virtual_machine.audio_device.enabled, null)
+  } : null
 
-    bios_global = try(var.config.proxmox.global.virtual_machine.bios, null)
+  bios_global = try(var.config.proxmox.global.virtual_machine.bios, null)
 
-    boot_order_global = try(var.config.proxmox.global.virtual_machine.boot_order, null)
+  boot_order_global = try(var.config.proxmox.global.virtual_machine.boot_order, null)
 
-    cpu_global = {
-        affinity = try(var.config.proxmox.global.virtual_machine.cpu.affinity, null)
-        cores = try(var.config.proxmox.global.virtual_machine.cpu.cores, null)
-        flags = try(var.config.proxmox.global.virtual_machine.cpu.flags, null)
-        hotplugged = try(var.config.proxmox.global.virtual_machine.cpu.hotplugged, null)
-        limit = try(var.config.proxmox.global.virtual_machine.cpu.limit, null)
-        numa = try(var.config.proxmox.global.virtual_machine.cpu.numa, null)
-        sockets = try(var.config.proxmox.global.virtual_machine.cpu.sockets, null)
-        type = try(var.config.proxmox.global.virtual_machine.cpu.type, null)
-        units = try(var.config.proxmox.global.virtual_machine.cpu.units, null)
-    }
+  cpu_global = try(var.config.proxmox.global.virtual_machine.cpu, null) != null ? {
+    affinity   = try(var.config.proxmox.global.virtual_machine.cpu.affinity, null)
+    cores      = try(var.config.proxmox.global.virtual_machine.cpu.cores, null)
+    flags      = try(var.config.proxmox.global.virtual_machine.cpu.flags, null)
+    hotplugged = try(var.config.proxmox.global.virtual_machine.cpu.hotplugged, null)
+    limit      = try(var.config.proxmox.global.virtual_machine.cpu.limit, null)
+    numa       = try(var.config.proxmox.global.virtual_machine.cpu.numa, null)
+    sockets    = try(var.config.proxmox.global.virtual_machine.cpu.sockets, null)
+    type       = try(var.config.proxmox.global.virtual_machine.cpu.type, null)
+    units      = try(var.config.proxmox.global.virtual_machine.cpu.units, null)
+  } : null
 
-    description_global = try(var.config.proxmox.global.virtual_machine.description, null)
+  description_global = try(var.config.proxmox.global.virtual_machine.description, null)
 
-    disk_global = {
-        aio = try(var.config.proxmox.global.virtual_machine.disk.aio, null)
-        backup = try(var.config.proxmox.global.virtual_machine.disk.backup, null)
-        cache = try(var.config.proxmox.global.virtual_machine.disk.cache, null)
-        datastore_id = try(var.config.proxmox.global.virtual_machine.disk.datastore_id, null)
-        discard = try(var.config.proxmox.global.virtual_machine.disk.discard, null)
-        file_format = try(var.config.proxmox.global.virtual_machine.disk.file_format, null)
-        file_id = try(var.config.proxmox.global.virtual_machine.disk.file_id, null)
-        interface = try(var.config.proxmox.global.virtual_machine.disk.interface, null)
-        iothread = try(var.config.proxmox.global.virtual_machine.disk.iothread, null)
-        replicate = try(var.config.proxmox.global.virtual_machine.disk.replicate, null)
-        serial = try(var.config.proxmox.global.virtual_machine.disk.serial, null)
-        size = try(var.config.proxmox.global.virtual_machine.disk.size, null)
-        ssd = try(var.config.proxmox.global.virtual_machine.disk.ssd, null)
-    }
+  disk_global = try(var.config.proxmox.global.virtual_machine.disk, null) != null ? {
+    aio          = try(var.config.proxmox.global.virtual_machine.disk.aio, null)
+    backup       = try(var.config.proxmox.global.virtual_machine.disk.backup, null)
+    cache        = try(var.config.proxmox.global.virtual_machine.disk.cache, null)
+    datastore_id = try(var.config.proxmox.global.virtual_machine.disk.datastore_id, null)
+    discard      = try(var.config.proxmox.global.virtual_machine.disk.discard, null)
+    file_format  = try(var.config.proxmox.global.virtual_machine.disk.file_format, null)
+    file_id      = try(var.config.proxmox.global.virtual_machine.disk.file_id, null)
+    interface    = try(var.config.proxmox.global.virtual_machine.disk.interface, null)
+    iothread     = try(var.config.proxmox.global.virtual_machine.disk.iothread, null)
+    replicate    = try(var.config.proxmox.global.virtual_machine.disk.replicate, null)
+    serial       = try(var.config.proxmox.global.virtual_machine.disk.serial, null)
+    size         = try(var.config.proxmox.global.virtual_machine.disk.size, null)
+    ssd          = try(var.config.proxmox.global.virtual_machine.disk.ssd, null)
+  } : null
 
-    machine_global = try(var.config.proxmox.global.virtual_machine.machine, null)
+  machine_global = try(var.config.proxmox.global.virtual_machine.machine, null)
 
-    memory_global = {
-        dedicated = try(var.config.proxmox.global.virtual_machine.memory.dedicated, null)
-        floating = try(var.config.proxmox.global.virtual_machine.memory.floating, null)
-        shared = try(var.config.proxmox.global.virtual_machine.memory.shared, null)
-    }
+  memory_global = try(var.config.proxmox.global.virtual_machine.memory, null) != null ? {
+    dedicated = try(var.config.proxmox.global.virtual_machine.memory.dedicated, null)
+    floating  = try(var.config.proxmox.global.virtual_machine.memory.floating, null)
+    shared    = try(var.config.proxmox.global.virtual_machine.memory.shared, null)
+  } : null
 
-    network_device_global = {
-        bridge = try(var.config.proxmox.global.virtual_machine.network_device.bridge, null)
-        disconnected = try(var.config.proxmox.global.virtual_machine.network_device.disconnected, null)
-        enabled = try(var.config.proxmox.global.virtual_machine.network_device.enabled, null)
-        firewall = try(var.config.proxmox.global.virtual_machine.network_device.firewall, null)
-        mac_address = try(var.config.proxmox.global.virtual_machine.network_device.mac_address, null)
-        model = try(var.config.proxmox.global.virtual_machine.network_device.model, null)
-    }
+  network_device_global = try(var.config.proxmox.global.virtual_machine.network_device, null) != null ? {
+    bridge       = try(var.config.proxmox.global.virtual_machine.network_device.bridge, null)
+    disconnected = try(var.config.proxmox.global.virtual_machine.network_device.disconnected, null)
+    enabled      = try(var.config.proxmox.global.virtual_machine.network_device.enabled, null)
+    firewall     = try(var.config.proxmox.global.virtual_machine.network_device.firewall, null)
+    mac_address  = try(var.config.proxmox.global.virtual_machine.network_device.mac_address, null)
+    model        = try(var.config.proxmox.global.virtual_machine.network_device.model, null)
+  } : null
 
-    node_name_global = try(var.config.proxmox.global.virtual_machine.node_name, null)
+  node_name_global = try(var.config.proxmox.global.virtual_machine.node_name, null)
 
-    on_boot_global = try(var.config.proxmox.global.virtual_machine.on_boot, null)
+  on_boot_global = try(var.config.proxmox.global.virtual_machine.on_boot, null)
 
-    operating_system_global = {
-        type = try(var.config.proxmox.global.virtual_machine.operating_system.type, null)
-    }
+  operating_system_global = try(var.config.proxmox.global.virtual_machine.operating_system, null) != null ? {
+    type = try(var.config.proxmox.global.virtual_machine.operating_system.type, null)
+  } : null
 
-    started_global = try(var.config.proxmox.global.virtual_machine.started, null)
+  started_global = try(var.config.proxmox.global.virtual_machine.started, null)
 
-    startup_global = {
-        order = try(var.config.proxmox.global.virtual_machine.startup.order, null)
-        up_delay = try(var.config.proxmox.global.virtual_machine.startup.up_delay, null)
-        down_delay = try(var.config.proxmox.global.virtual_machine.startup.down_delay, null)
-    }
+  startup_global = try(var.config.proxmox.global.virtual_machine.startup, null) != null ? {
+    order      = try(var.config.proxmox.global.virtual_machine.startup.order, null)
+    up_delay   = try(var.config.proxmox.global.virtual_machine.startup.up_delay, null)
+    down_delay = try(var.config.proxmox.global.virtual_machine.startup.down_delay, null)
+  } : null
 
-    tags_global = try(var.config.proxmox.global.virtual_machine.tags, null)
+  tags_global = try(var.config.proxmox.global.virtual_machine.tags, null)
 
-    stop_on_destroy_global = try(var.config.proxmox.global.virtual_machine.stop_on_destroy, null)
+  stop_on_destroy_global = try(var.config.proxmox.global.virtual_machine.stop_on_destroy, null)
 
-    vga_global = {
-        memory = try(var.config.proxmox.global.virtual_machine.vga.memory, null)
-        type = try(var.config.proxmox.global.virtual_machine.vga.type, null)
-        clipboard = try(var.config.proxmox.global.virtual_machine.vga.clipboard, null)
-    }
+  vga_global = try(var.config.proxmox.global.virtual_machine.vga, null) != null ? {
+    memory    = try(var.config.proxmox.global.virtual_machine.vga.memory, null)
+    type      = try(var.config.proxmox.global.virtual_machine.vga.type, null)
+    clipboard = try(var.config.proxmox.global.virtual_machine.vga.clipboard, null)
+  } : null
 }

--- a/terraform/module/proxmox/virtual_machine/input.tf
+++ b/terraform/module/proxmox/virtual_machine/input.tf
@@ -1,93 +1,93 @@
 locals {
-    agent_input = {
-        enabled = try(var.agent.enabled, null)
-        timeout = try(var.agent.timeout, null)
-        trim = try(var.agent.trim, null)
-        type = try(var.agent.type, null)
-    }
+  agent_input = try(var.agent, null) != null ? {
+    enabled = try(var.agent.enabled, null)
+    timeout = try(var.agent.timeout, null)
+    trim    = try(var.agent.trim, null)
+    type    = try(var.agent.type, null)
+  } : null
 
-    audio_device_input = try(var.audio_device, null) != null ? {
-        device = try(var.audio_device.device, null)
-        driver = try(var.audio_device.driver, null)
-        enabled = try(var.audio_device.enabled, null)
-    } : null
+  audio_device_input = try(var.audio_device, null) != null ? {
+    device  = try(var.audio_device.device, null)
+    driver  = try(var.audio_device.driver, null)
+    enabled = try(var.audio_device.enabled, null)
+  } : null
 
-    bios_input = try(var.bios, null)
+  bios_input = try(var.bios, null)
 
-    boot_order_input = try(var.boot_order, null)
+  boot_order_input = try(var.boot_order, null)
 
-    cpu_input = {
-        affinity = try(var.cpu.affinity, null)
-        cores = try(var.cpu.cores, null)
-        flags = try(var.cpu.flags, null)
-        hotplugged = try(var.cpu.hotplugged, null)
-        limit = try(var.cpu.limit, null)
-        numa = try(var.cpu.numa, null)
-        sockets = try(var.cpu.sockets, null)
-        type = try(var.cpu.type, null)
-        units =try(var.cpu.units, null)
-    }
+  cpu_input = try(var.cpu, null) != null ? {
+    affinity   = try(var.cpu.affinity, null)
+    cores      = try(var.cpu.cores, null)
+    flags      = try(var.cpu.flags, null)
+    hotplugged = try(var.cpu.hotplugged, null)
+    limit      = try(var.cpu.limit, null)
+    numa       = try(var.cpu.numa, null)
+    sockets    = try(var.cpu.sockets, null)
+    type       = try(var.cpu.type, null)
+    units      = try(var.cpu.units, null)
+  } : null
 
-    description_input = try(var.description, null)
+  description_input = try(var.description, null)
 
-    disk_input = {
-        aio = try(var.disk.aio, null)
-        backup = try(var.disk.backup, null)
-        cache = try(var.disk.cache, null)
-        datastore_id = try(var.disk.datastore_id, null)
-        discard = try(var.disk.discard, null)
-        file_format = try(var.disk.file_format, null)
-        file_id = try(var.disk.file_id, null)
-        interface = try(var.disk.interface, null)
-        iothread = try(var.disk.iothread, null)
-        replicate = try(var.disk.replicate, null)
-        serial = try(var.disk.serial, null)
-        size = try(var.disk.size, null)
-        ssd = try(var.disk.ssd, null)
-    }
+  disk_input = try(var.disk, null) != null ? {
+    aio          = try(var.disk.aio, null)
+    backup       = try(var.disk.backup, null)
+    cache        = try(var.disk.cache, null)
+    datastore_id = try(var.disk.datastore_id, null)
+    discard      = try(var.disk.discard, null)
+    file_format  = try(var.disk.file_format, null)
+    file_id      = try(var.disk.file_id, null)
+    interface    = try(var.disk.interface, null)
+    iothread     = try(var.disk.iothread, null)
+    replicate    = try(var.disk.replicate, null)
+    serial       = try(var.disk.serial, null)
+    size         = try(var.disk.size, null)
+    ssd          = try(var.disk.ssd, null)
+  } : null
 
-    machine_input = try(var.machine, null)
+  machine_input = try(var.machine, null)
 
-    memory_input = {
-        dedicated = try(var.memory.dedicated, null)
-        floating = try(var.memory.floating, null)
-        shared = try(var.memory.shared, null)
-    }
+  memory_input = try(var.memory, null) != null ? {
+    dedicated = try(var.memory.dedicated, null)
+    floating  = try(var.memory.floating, null)
+    shared    = try(var.memory.shared, null)
+  } : null
 
-    network_device_input = {
-        bridge = try(var.network_device.bridge, null)
-        disconnected = try(var.network_device.disconnected, null)
-        enabled = try(var.network_device.enabled, null)
-        firewall = try(var.network_device.firewall, null)
-        mac_address = try(var.network_device.mac_address, null)
-        model = try(var.network_device.model, null)
-    }
+  network_device_input = try(var.network_device, null) != null ? {
+    bridge       = try(var.network_device.bridge, null)
+    disconnected = try(var.network_device.disconnected, null)
+    enabled      = try(var.network_device.enabled, null)
+    firewall     = try(var.network_device.firewall, null)
+    mac_address  = try(var.network_device.mac_address, null)
+    model        = try(var.network_device.model, null)
+  } : null
 
-    node_name_input = try(var.node_name, null)
+  node_name_input = try(var.node_name, null)
 
-    on_boot_input = try(var.on_boot, null)
+  on_boot_input = try(var.on_boot, null)
 
-    operating_system_input = {
-        type = try(var.operating_system.type, null)
-    }
+  operating_system_input = try(var.operating_system, null) != null ? {
+    type = try(var.operating_system.type, null)
+  } : null
 
-    started_input = try(var.started, null)
+  started_input = try(var.started, null)
 
-    startup_input = {
-        order = try(var.startup.order, null)
-        up_delay = try(var.startup.up_delay, null)
-        down_delay = try(var.startup.down_delay, null)
-    }
+  startup_input = try(var.startup, null) != null ? {
+    order      = try(var.startup.order, null)
+    up_delay   = try(var.startup.up_delay, null)
+    down_delay = try(var.startup.down_delay, null)
+  } : null
 
-    tags_input = try(var.tags, null)
+  tags_input = try(var.tags, null)
 
-    stop_on_destroy_input = try(var.stop_on_destroy, null)
+  stop_on_destroy_input = try(var.stop_on_destroy, null)
 
-    vga_input = {
-        memory = try(var.vga.memory, null)
-        type = try(var.vga.type, null)
-        clipboard = try(var.vga.clipboard, null)
-    }
+  vga_input = try(var.vga, null) != null ? {
+    memory    = try(var.vga.memory, null)
+    type      = try(var.vga.type, null)
+    clipboard = try(var.vga.clipboard, null)
+  } : null
 
-    vm_id_input = try(var.vm_id, null)
+  vm_id_input = try(var.vm_id, null)
 }

--- a/terraform/module/proxmox/virtual_machine/main.tf
+++ b/terraform/module/proxmox/virtual_machine/main.tf
@@ -20,8 +20,8 @@ module "cloud_init" {
 module "image" {
   source = "../image"
 
-  config = var.config
-  name = try(var.name, "fallback")
+  config       = var.config
+  name         = try(var.name, "fallback")
   datastore_id = try(var.cloud_init.datastore_id, null)
 }
 
@@ -31,11 +31,14 @@ resource "proxmox_virtual_environment_vm" "virtual_machine" {
     module.image,
   ]
 
-  agent {
-    enabled = local.agent_computed.enabled
-    timeout = "5m"
-    trim    = local.agent_computed.trim
-    type    = local.agent_computed.type
+  dynamic "agent" {
+    for_each = local.agent_computed != null ? [1] : []
+    content {
+      enabled = local.agent_computed.enabled
+      timeout = "5m"
+      trim    = local.agent_computed.trim
+      type    = local.agent_computed.type
+    }
   }
 
   dynamic "audio_device" {
@@ -50,34 +53,40 @@ resource "proxmox_virtual_environment_vm" "virtual_machine" {
   bios       = "seabios"
   boot_order = local.boot_order_computed
 
-  cpu {
-    affinity   = local.cpu_computed.affinity
-    cores      = local.cpu_computed.cores
-    flags      = local.cpu_computed.flags
-    hotplugged = local.cpu_computed.hotplugged
-    limit      = local.cpu_computed.limit
-    numa       = local.cpu_computed.numa
-    sockets    = local.cpu_computed.sockets
-    type       = local.cpu_computed.type
-    units      = local.cpu_computed.units
+  dynamic "cpu" {
+    for_each = local.cpu_computed != null ? [1] : []
+    content {
+      affinity   = local.cpu_computed.affinity
+      cores      = local.cpu_computed.cores
+      flags      = local.cpu_computed.flags
+      hotplugged = local.cpu_computed.hotplugged
+      limit      = local.cpu_computed.limit
+      numa       = local.cpu_computed.numa
+      sockets    = local.cpu_computed.sockets
+      type       = local.cpu_computed.type
+      units      = local.cpu_computed.units
+    }
   }
 
   description = local.description_computed
 
-  disk {
-    aio          = local.disk_computed.aio
-    backup       = local.disk_computed.backup
-    cache        = local.disk_computed.cache
-    datastore_id = local.disk_computed.datastore_id
-    discard      = local.disk_computed.discard
-    file_format  = local.disk_computed.file_format
-    file_id      = local.disk_computed.file_id
-    interface    = local.disk_computed.interface
-    iothread     = local.disk_computed.iothread
-    replicate    = local.disk_computed.replicate
-    serial       = local.disk_computed.serial
-    size         = local.disk_computed.size
-    ssd          = local.disk_computed.ssd
+  dynamic "disk" {
+    for_each = local.disk_computed != null ? [1] : []
+    content {
+      aio          = local.disk_computed.aio
+      backup       = local.disk_computed.backup
+      cache        = local.disk_computed.cache
+      datastore_id = local.disk_computed.datastore_id
+      discard      = local.disk_computed.discard
+      file_format  = local.disk_computed.file_format
+      file_id      = local.disk_computed.file_id
+      interface    = local.disk_computed.interface
+      iothread     = local.disk_computed.iothread
+      replicate    = local.disk_computed.replicate
+      serial       = local.disk_computed.serial
+      size         = local.disk_computed.size
+      ssd          = local.disk_computed.ssd
+    }
   }
 
   initialization {
@@ -87,43 +96,58 @@ resource "proxmox_virtual_environment_vm" "virtual_machine" {
 
   machine = local.machine_computed
 
-  memory {
-    dedicated = local.memory_computed.dedicated
-    floating  = local.memory_computed.floating
-    shared    = local.memory_computed.shared
+  dynamic "memory" {
+    for_each = local.memory_computed != null ? [1] : []
+    content {
+      dedicated = local.memory_computed.dedicated
+      floating  = local.memory_computed.floating
+      shared    = local.memory_computed.shared
+    }
   }
 
-  network_device {
-    bridge       = local.network_device_computed.bridge
-    disconnected = local.network_device_computed.disconnected
-    enabled      = local.network_device_computed.enabled
-    firewall     = local.network_device_computed.firewall
-    mac_address  = local.network_device_computed.mac_address
-    model        = local.network_device_computed.model
+  dynamic "network_device" {
+    for_each = local.network_device_computed != null ? [1] : []
+    content {
+      bridge       = local.network_device_computed.bridge
+      disconnected = local.network_device_computed.disconnected
+      enabled      = local.network_device_computed.enabled
+      firewall     = local.network_device_computed.firewall
+      mac_address  = local.network_device_computed.mac_address
+      model        = local.network_device_computed.model
+    }
   }
 
   node_name = local.node_name_computed
   on_boot   = local.on_boot_computed
 
-  operating_system {
-    type = local.operating_system_computed.type
+  dynamic "operating_system" {
+    for_each = local.operating_system_computed != null ? [1] : []
+    content {
+      type = local.operating_system_computed.type
+    }
   }
 
   started = local.started_computed
 
-  startup {
-    order      = local.startup_computed.order
-    up_delay   = local.startup_computed.up_delay
-    down_delay = local.startup_computed.down_delay
+  dynamic "startup" {
+    for_each = local.startup_computed != null ? [1] : []
+    content {
+      order      = local.startup_computed.order
+      up_delay   = local.startup_computed.up_delay
+      down_delay = local.startup_computed.down_delay
+    }
   }
 
   tags            = local.tags_computed
   stop_on_destroy = local.stop_on_destroy_computed
 
-  vga {
-    memory    = local.vga_computed.memory
-    type      = local.vga_computed.type
-    clipboard = local.vga_computed.clipboard
+  dynamic "vga" {
+    for_each = local.vga_computed != null ? [1] : []
+    content {
+      memory    = local.vga_computed.memory
+      type      = local.vga_computed.type
+      clipboard = local.vga_computed.clipboard
+    }
   }
 
   vm_id = local.vm_id_computed


### PR DESCRIPTION
## Summary
- make complex VM attributes optional in `input.tf`, `global.tf`, and `computed.tf`
- update `main.tf` to use dynamic blocks when optional objects are provided

## Testing
- `terraform init -backend=false` *(fails: could not connect to registry)*

------
https://chatgpt.com/codex/tasks/task_e_687d928f30fc832c861032d2f4b54f9d